### PR TITLE
Allow auth without a service account key file

### DIFF
--- a/flatcar-google-image-uploader
+++ b/flatcar-google-image-uploader
@@ -8,7 +8,9 @@ SLEEP_DURATION="${SLEEP_DURATION:-"3600"}"
 GOOGLE_SA_KEY_FILE="${GOOGLE_SA_KEY_FILE:-"./credentials.json"}"
 
 # configure auth with the provided service account key file
-gcloud auth activate-service-account --key-file "${GOOGLE_SA_KEY_FILE}"
+if [[ -f "${GOOGLE_SA_KEY_FILE}" ]]; then
+  gcloud auth activate-service-account --key-file "${GOOGLE_SA_KEY_FILE}"
+fi
 
 while true; do
   # retrieve the version number of the current release


### PR DESCRIPTION
This adds support for pre-existing credentials configuration and the GCE metadata server.